### PR TITLE
Allow `requirements_in_conda` and `biocontainer_registered` in skip_file

### DIFF
--- a/planemo/lint.py
+++ b/planemo/lint.py
@@ -46,7 +46,7 @@ def build_lint_args(ctx: "PlanemoCliContext", **kwds) -> Dict[str, Any]:
                 skip_types.append(line)
 
     linters = Linter.list_linters()
-    linters.extend(["version_bumped"])
+    linters.extend(["version_bumped", "requirements_in_conda", "biocontainer_registered"])
     invalid_skip_types = list(set(skip_types) - set(linters))
     if len(invalid_skip_types):
         error(f"Unknown linter type(s) {invalid_skip_types} in list of linters to be skipped. Known linters {linters}")


### PR DESCRIPTION
This PR supersedes #1558.

This PR allows adding `requirements_in_conda` and `biocontainer_registered` to the skip_file.

I tested this locally and it works.